### PR TITLE
Fix JS error on addEventListener in IE8

### DIFF
--- a/src/knockout.files.js
+++ b/src/knockout.files.js
@@ -102,6 +102,10 @@
 				}
 			};
 
+			if (!document.addEventListener) {
+				return; //IE8 won't work with addEventListener, avoid JS error
+			}
+
 			element.addEventListener('change', handleFileSelected, false);
 
 			if(allowDrop) {


### PR DESCRIPTION
File API won't work in either IE8 or IE9, but this fixes a bug where IE8 got an JS error that prevented other scripts from executing
